### PR TITLE
Added redis db to sync servers

### DIFF
--- a/Docker/docker-compose/docker-compose-redis.yml
+++ b/Docker/docker-compose/docker-compose-redis.yml
@@ -1,0 +1,7 @@
+version: '3.0'
+services:
+  redis:
+    image: redis:latest
+    container_name: redis
+    ports:
+      - 6379:6379

--- a/Docker/nginx/conf/default.conf
+++ b/Docker/nginx/conf/default.conf
@@ -1,5 +1,6 @@
 #/etc/nginx/conf.d/default.conf
 upstream lb {
+  least_conn;
   include servers;
 }
 

--- a/Docker/rasa/server/entrypoint.sh
+++ b/Docker/rasa/server/entrypoint.sh
@@ -4,4 +4,4 @@
 source /app/secrets/telegram_secrets.env
 
 # run rasa
-rasa run -m /app/models --enable-api --cors * --debug --endpoints endpoints.yml --log-file logs/rasa.log --debug
+rasa run -m /app/models --enable-api --cors * --debug --endpoints endpoints.yml --credendials credentials.yml --log-file logs/rasa.log --debug

--- a/endpoints.yml
+++ b/endpoints.yml
@@ -17,16 +17,24 @@ action_endpoint:
 # By default the conversations are stored in memory.
 # https://rasa.com/docs/rasa/tracker-stores
 
-#tracker_store:
-#    type: redis
-#    url: <host of the redis instance, e.g. localhost>
-#    port: <port of your redis instance, usually 6379>
-#    db: <number of your database within redis, e.g. 0>
-#    password: <password used for authentication>
-#    use_ssl: <whether or not the communication is encrypted, default false>
-
 tracker_store:
-  type: sql
+    type: redis
+    url: load-balancer-ip
+    port: 6379
+    db: 1
+    password:
+
+
+lock_store:
+    type: redis
+    url: load-balancer-ip
+    port: 6379
+    db: 0
+    password:
+    key_prefix: rasa
+
+#tracker_store:
+#  type: sql
 
 #tracker_store:
 #    type: mongod


### PR DESCRIPTION
This pr changes the internal db of rasa from sql to redis, which allows synchronizing the requests made to all the rasa servers so that when balancing the requests made, it always accesses the same db